### PR TITLE
feat: 회원가입, 로그인 페이지에 유효성 검사 추가

### DIFF
--- a/src/components/auth/LoginForm/LoginForm.tsx
+++ b/src/components/auth/LoginForm/LoginForm.tsx
@@ -1,0 +1,45 @@
+import { useCallback, useMemo } from "react";
+import useInput from "../../../hook/common/useInput";
+import Button from "../../common/Button/Button";
+import { validator } from "../../../util/validator";
+import { S } from "./style";
+import Input from "../../common/Input/Input";
+
+export default function LoginForm() {
+  const [email, isValidEmail] = useInput("", validator.email);
+  const [password, isValidPw] = useInput("", validator.password);
+  const isDisabled = useMemo(() => ![isValidEmail.value, isValidPw.value].every((valid) => valid), [isValidEmail, isValidPw]);
+
+  const handleSubmit = useCallback((e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+  }, []);
+
+  return (
+    <S.FormContainer onSubmit={handleSubmit}>
+      <Input
+        label="이메일"
+        id="email"
+        type="text"
+        placeholder="사용하실 이메일을 입력해주세요."
+        data-testid="email-input"
+        required
+        {...email}
+        error={isValidEmail.message}
+      />
+      <Input
+        label="패스워드"
+        id="password"
+        type="password"
+        placeholder="8자리 이상 패스워드를 입력해주세요."
+        data-testid="password-input"
+        required
+        {...password}
+        error={isValidPw.message}
+      />
+      <Button bgColor="--accent-color" txtColor="white" data-testid="signin-button" disabled={isDisabled}>
+        로그인
+      </Button>
+      <S.RegisterLink to="/signup">회원가입 하러가기 ➡</S.RegisterLink>
+    </S.FormContainer>
+  );
+}

--- a/src/components/auth/LoginForm/style.tsx
+++ b/src/components/auth/LoginForm/style.tsx
@@ -1,0 +1,23 @@
+import { Link } from "react-router-dom";
+import styled from "styled-components";
+
+const FormContainer = styled.form`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 40px;
+  padding-bottom: 20px;
+
+  button {
+    margin-bottom: 10px;
+  }
+`;
+
+const RegisterLink = styled(Link)`
+  color: var(--bg-color);
+`;
+
+export const S = {
+  FormContainer,
+  RegisterLink,
+};

--- a/src/components/auth/RegisterForm/RegisterForm.tsx
+++ b/src/components/auth/RegisterForm/RegisterForm.tsx
@@ -1,0 +1,64 @@
+import { useMemo, useCallback, useState } from "react";
+import useInput from "../../../hook/common/useInput";
+import { validator, ValidationError } from "../../../util/validator";
+import Button from "../../common/Button/Button";
+import ErrorMessage from "../../common/ErrorMessage/ErrorMessage";
+import Input from "../../common/Input/Input";
+import { S } from "./style";
+
+export default function RegisterForm() {
+  const [email, isValidEmail] = useInput("", validator.email);
+  const [password, isValidPw] = useInput("", validator.password);
+  const [passwordCheck, isValidPwCheck] = useInput("", validator.password);
+  const [error, setError] = useState("");
+  const isDisabled = useMemo(() => ![isValidEmail, isValidPw, isValidPwCheck].every((valid) => valid), [isValidEmail, isValidPw, isValidPwCheck]);
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      if (password.value !== passwordCheck.value) {
+        return setError(ValidationError.PASSWORD_CHECK_ERROR);
+      }
+      setError("");
+    },
+    [password.value, passwordCheck.value]
+  );
+
+  return (
+    <S.FormContainer onSubmit={handleSubmit}>
+      <Input
+        label="이메일"
+        id="email"
+        type="text"
+        placeholder="사용하실 이메일을 입력해주세요."
+        data-testid="email-input"
+        required
+        {...email}
+        error={isValidEmail.message}
+      />
+      <Input
+        label="패스워드"
+        id="password"
+        type="password"
+        placeholder="8자리 이상 패스워드를 입력해주세요."
+        data-testid="password-input"
+        required
+        {...password}
+        error={isValidPw.message}
+      />
+      <Input
+        label="패스워드 확인"
+        id="passwordCheck"
+        type="password"
+        placeholder="패스워드와 동일하게 작성해주세요."
+        required
+        {...passwordCheck}
+        error={isValidPwCheck.message}
+      />
+      <ErrorMessage>{error}</ErrorMessage>
+      <Button bgColor="--accent-color" txtColor="white" data-testid="signup-button" disabled={isDisabled}>
+        회원가입
+      </Button>
+    </S.FormContainer>
+  );
+}

--- a/src/components/auth/RegisterForm/style.tsx
+++ b/src/components/auth/RegisterForm/style.tsx
@@ -1,0 +1,23 @@
+import styled from "styled-components";
+import { Link } from "react-router-dom";
+
+const FormContainer = styled.form`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 40px;
+  padding-bottom: 20px;
+
+  button {
+    margin-bottom: 10px;
+  }
+`;
+
+const RegisterLink = styled(Link)`
+  color: var(--bg-color);
+`;
+
+export const S = {
+  FormContainer,
+  RegisterLink,
+};

--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -2,9 +2,15 @@ import { S } from "./style";
 
 interface Props {
   children: string | JSX.Element;
-  theme?: string;
+  bgColor?: string;
+  txtColor?: string;
+  disabled?: boolean;
 }
 
-export default function Button({ children, theme }: Props) {
-  return <S.Button theme={theme}>{children}</S.Button>;
+export default function Button({ children, bgColor, txtColor, disabled = false }: Props) {
+  return (
+    <S.Button bgColor={bgColor} txtColor={txtColor} disabled={disabled}>
+      {children}
+    </S.Button>
+  );
 }

--- a/src/components/common/Button/style.tsx
+++ b/src/components/common/Button/style.tsx
@@ -15,8 +15,8 @@ const Button = styled.button`
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: var(${(props: Props) => (props.disabled ? "#88304E" : props.bgColor)});
-  color: ${(props: Props) => (props.disabled ? "#555555" : props.txtColor)};
+  background-color: ${(props: Props) => (props.disabled ? "#aaa" : `var(${props.bgColor})`)};
+  color: ${(props: Props) => (props.disabled ? `#444` : props.txtColor)};
   font-size: 2rem;
   cursor: pointer;
 `;

--- a/src/components/common/Button/style.tsx
+++ b/src/components/common/Button/style.tsx
@@ -1,16 +1,22 @@
 import styled from "styled-components";
 
 interface Props {
-  theme: string;
+  bgColor?: string;
+  txtColor?: string;
+  disabled?: boolean;
 }
 
 const Button = styled.button`
   border: none;
-  width: 120px;
+  min-width: 120px;
+  padding: 5px 10px;
   height: 30px;
   border-radius: 5px;
-  background-color: var(${(props: Props) => (props.theme === "red" ? "--accent-color" : "--color-type-04")});
-  color: ${(props: Props) => (props.theme === "red" ? "white" : "black")};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: var(${(props: Props) => (props.disabled ? "#88304E" : props.bgColor)});
+  color: ${(props: Props) => (props.disabled ? "#555555" : props.txtColor)};
   font-size: 2rem;
   cursor: pointer;
 `;

--- a/src/components/common/ErrorMessage/ErrorMessage.tsx
+++ b/src/components/common/ErrorMessage/ErrorMessage.tsx
@@ -1,0 +1,5 @@
+import { S } from "./style";
+
+export default function ErrorMessage({ children, className }: { children?: string; className?: string }) {
+  return <S.Container className={className}>{children}</S.Container>;
+}

--- a/src/components/common/ErrorMessage/style.tsx
+++ b/src/components/common/ErrorMessage/style.tsx
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+
+const Container = styled.p`
+  color: red;
+`;
+
+export const S = {
+  Container,
+};

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -1,0 +1,22 @@
+import { S } from "./style";
+
+interface Props {
+  id: string;
+  label: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  placeholder: string;
+  error: string;
+  required: boolean;
+  type: string;
+  value: string;
+}
+
+export default function Input({ id, label, error, ...rest }: Partial<Props>) {
+  return (
+    <>
+      <S.Label htmlFor={id}>{label}</S.Label>
+      <S.Input id={id} {...rest} />
+      <S.InputErrorMessage>{error}</S.InputErrorMessage>
+    </>
+  );
+}

--- a/src/components/common/Input/style.tsx
+++ b/src/components/common/Input/style.tsx
@@ -1,0 +1,29 @@
+import styled from "styled-components";
+import ErrorMessage from "../ErrorMessage/ErrorMessage";
+
+const Label = styled.label`
+  align-self: flex-start;
+  margin-left: 40px;
+  margin-bottom: 5px;
+`;
+
+const Input = styled.input`
+  width: 330px;
+  height: 40px;
+  padding-left: 10px;
+  border-radius: 5px;
+  border: none;
+  background-color: var(--color-type-04);
+  font-size: 1.6rem;
+`;
+
+const InputErrorMessage = styled(ErrorMessage)`
+  margin-top: 5px;
+  margin-bottom: 20px;
+`;
+
+export const S = {
+  Label,
+  Input,
+  InputErrorMessage,
+};

--- a/src/hook/common/useInput.ts
+++ b/src/hook/common/useInput.ts
@@ -1,10 +1,15 @@
 import React, { useRef, useState } from "react";
 
-type Return = [{ value: string; onChange: (e: React.ChangeEvent<HTMLInputElement>) => void }, boolean];
+type Return = [{ value: string; onChange: (e: React.ChangeEvent<HTMLInputElement>) => void }, ValidatorReturn];
 
-export default function useInput(initValue: string, validator?: (value: string) => boolean): Return {
+type ValidatorReturn = {
+  value: boolean;
+  message?: string;
+};
+
+export default function useInput(initValue: string, validator?: (value: string) => ValidatorReturn): Return {
   const [value, setValue] = useState(initValue);
-  const result = useRef(false);
+  const result = useRef<ValidatorReturn>({ value: false });
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target;

--- a/src/hook/common/useInput.ts
+++ b/src/hook/common/useInput.ts
@@ -1,0 +1,20 @@
+import React, { useRef, useState } from "react";
+
+type Return = [{ value: string; onChange: (e: React.ChangeEvent<HTMLInputElement>) => void }, boolean];
+
+export default function useInput(initValue: string, validator?: (value: string) => boolean): Return {
+  const [value, setValue] = useState(initValue);
+  const result = useRef(false);
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target;
+
+    if (typeof validator === "function") {
+      result.current = validator(value);
+    }
+
+    setValue(value);
+  };
+
+  return [{ value, onChange }, result.current];
+}

--- a/src/pages/SignIn/SignIn.tsx
+++ b/src/pages/SignIn/SignIn.tsx
@@ -1,4 +1,4 @@
-import Button from "../../components/common/Button/Button";
+import LoginForm from "../../components/auth/LoginForm/LoginForm";
 import { S } from "./style";
 
 export default function SignIn() {
@@ -6,13 +6,8 @@ export default function SignIn() {
     <main>
       <h1 className="ir-hidden">로그인 페이지</h1>
       <S.Container>
-        <S.Title>로그인 폼</S.Title>
-        <S.FormContainer>
-          <input type="text" placeholder="이메일" />
-          <input type="text" placeholder="패스워드" />
-          <Button theme="red">로그인</Button>
-          <Button>회원가입</Button>
-        </S.FormContainer>
+        <S.Title>로그인</S.Title>
+        <LoginForm />
       </S.Container>
     </main>
   );

--- a/src/pages/SignIn/style.tsx
+++ b/src/pages/SignIn/style.tsx
@@ -6,7 +6,6 @@ const Container = styled.article`
   left: 50%;
   transform: translate(-50%, -50%);
   width: 400px;
-  height: 300px;
   background-color: var(--color-type-01);
 `;
 
@@ -22,30 +21,7 @@ const Title = styled.h2`
   font-size: 2rem;
 `;
 
-const FormContainer = styled.form`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding-top: 40px;
-
-  input {
-    width: 330px;
-    height: 40px;
-    padding-left: 10px;
-    margin-bottom: 25px;
-    border-radius: 5px;
-    border: none;
-    background-color: var(--color-type-04);
-    font-size: 2rem;
-  }
-
-  button {
-    margin-bottom: 10px;
-  }
-`;
-
 export const S = {
   Container,
   Title,
-  FormContainer,
 };

--- a/src/pages/SignUp/SignUp.tsx
+++ b/src/pages/SignUp/SignUp.tsx
@@ -1,4 +1,4 @@
-import Button from "../../components/common/Button/Button";
+import RegisterForm from "../../components/auth/RegisterForm/RegisterForm";
 import { S } from "./style";
 
 export default function SignUp() {
@@ -7,12 +7,7 @@ export default function SignUp() {
       <h1 className="ir-hidden">회원가입 페이지</h1>
       <S.Container>
         <S.Title>회원가입</S.Title>
-        <S.FormContainer>
-          <input type="email" placeholder="이메일" />
-          <input type="password" placeholder="패스워드" />
-          <input type="password" placeholder="패스워드 확인" />
-          <Button theme="red">회원가입</Button>
-        </S.FormContainer>
+        <RegisterForm />
       </S.Container>
     </main>
   );

--- a/src/pages/SignUp/style.tsx
+++ b/src/pages/SignUp/style.tsx
@@ -6,7 +6,6 @@ const Container = styled.article`
   left: 50%;
   transform: translate(-50%, -50%);
   width: 400px;
-  height: 300px;
   background-color: var(--color-type-01);
 `;
 
@@ -27,16 +26,23 @@ const FormContainer = styled.form`
   flex-direction: column;
   align-items: center;
   padding-top: 40px;
+  padding-bottom: 20px;
+
+  label {
+    align-self: flex-start;
+    margin-left: 40px;
+    margin-bottom: 5px;
+  }
 
   input {
     width: 330px;
     height: 40px;
     padding-left: 10px;
-    margin-bottom: 10px;
+    margin-bottom: 25px;
     border-radius: 5px;
     border: none;
     background-color: var(--color-type-04);
-    font-size: 2rem;
+    font-size: 1.6rem;
   }
 
   button {

--- a/src/util/validator.ts
+++ b/src/util/validator.ts
@@ -1,0 +1,12 @@
+export const validator = {
+  email: (value: string) => {
+    return VALIDATE_PATTERN.EMAIL.test(value);
+  },
+  password: (value: string) => {
+    return value.length >= 8;
+  },
+};
+
+const VALIDATE_PATTERN = {
+  EMAIL: /@/,
+};

--- a/src/util/validator.ts
+++ b/src/util/validator.ts
@@ -1,12 +1,26 @@
 export const validator = {
   email: (value: string) => {
-    return VALIDATE_PATTERN.EMAIL.test(value);
+    const result = VALIDATE_PATTERN.EMAIL.test(value);
+    return {
+      value: result,
+      message: result ? "" : ValidationError.EMAIL_ERROR,
+    };
   },
   password: (value: string) => {
-    return value.length >= 8;
+    const result = value.length >= 8;
+    return {
+      value: result,
+      message: result ? "" : ValidationError.PASSWORD_ERROR,
+    };
   },
 };
 
 const VALIDATE_PATTERN = {
   EMAIL: /@/,
+};
+
+export const ValidationError = {
+  EMAIL_ERROR: "@를 포함하여 입력해주세요.",
+  PASSWORD_ERROR: "8자리 이상 입력해주세요.",
+  PASSWORD_CHECK_ERROR: "패스워드와 동일하게 입력해주세요.",
 };


### PR DESCRIPTION
# 회원가입, 로그인 페이지에 유효성 검사 추가

## 작업 내용
- [x] useInput 커스텀 훅 생성
- [x] 회원가입 페이지 유효성 검사 추가
- [x] 로그인 페이지 유효성 검사 추가

## 추가 작업 내용
- ErrorMessage 컴포넌트 생성
- SignIn 페이지에서 LoginForm 컴포넌트로 분리
- SignUp 페이지에서 RegisterForm 컴포넌트로 분리
- Button 컴포넌트 스타일 수정

close : #7